### PR TITLE
Removed unneeded NetResource structure

### DIFF
--- a/pkg/sriov/networkservice/freevfsinfo/server_test.go
+++ b/pkg/sriov/networkservice/freevfsinfo/server_test.go
@@ -36,32 +36,26 @@ func TestNewClient_AddFreeVirtualFunctionsInfo(t *testing.T) {
 
 	resourcePool := &sriov.NetResourcePool{
 		HostName: "example.com",
-		Resources: []*sriov.NetResource{
+		PhysicalFunctions: []*sriov.PhysicalFunction{
 			{
-				PhysicalFunction: &sriov.PhysicalFunction{
-					PCIAddress: "0000:00:01:0",
-					VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
-						{}: sriov.FreeVirtualFunction,
-						{}: sriov.FreeVirtualFunction,
-					},
+				PCIAddress: "0000:00:01:0",
+				VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
+					{}: sriov.FreeVirtualFunction,
+					{}: sriov.FreeVirtualFunction,
 				},
 			},
 			{
-				PhysicalFunction: &sriov.PhysicalFunction{
-					PCIAddress: "0000:00:02:0",
-					VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
-						{}: sriov.FreeVirtualFunction,
-						{}: sriov.UsedVirtualFunction,
-					},
+				PCIAddress: "0000:00:02:0",
+				VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
+					{}: sriov.FreeVirtualFunction,
+					{}: sriov.UsedVirtualFunction,
 				},
 			},
 			{
-				PhysicalFunction: &sriov.PhysicalFunction{
-					PCIAddress: "0000:00:03:0",
-					VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
-						{}: sriov.UsedVirtualFunction,
-						{}: sriov.UsedVirtualFunction,
-					},
+				PCIAddress: "0000:00:03:0",
+				VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
+					{}: sriov.UsedVirtualFunction,
+					{}: sriov.UsedVirtualFunction,
 				},
 			},
 		},

--- a/pkg/sriov/networkservice/mechanisms/kernel/server_test.go
+++ b/pkg/sriov/networkservice/mechanisms/kernel/server_test.go
@@ -68,14 +68,12 @@ func TestNewServer_SelectVirtualFunction(t *testing.T) {
 
 	vf1, vf2 := initVfs()
 	resourcePool := &sriov.NetResourcePool{
-		Resources: []*sriov.NetResource{
+		PhysicalFunctions: []*sriov.PhysicalFunction{
 			{
-				PhysicalFunction: &sriov.PhysicalFunction{
-					PCIAddress: pfPCIAddress,
-					VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
-						vf1: sriov.UsedVirtualFunction,
-						vf2: sriov.FreeVirtualFunction,
-					},
+				PCIAddress: pfPCIAddress,
+				VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
+					vf1: sriov.UsedVirtualFunction,
+					vf2: sriov.FreeVirtualFunction,
 				},
 			},
 		},
@@ -105,7 +103,7 @@ func TestNewServer_SelectVirtualFunction(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, conn)
 
-	selectedVfState := resourcePool.Resources[0].PhysicalFunction.VirtualFunctions[vf2]
+	selectedVfState := resourcePool.PhysicalFunctions[0].VirtualFunctions[vf2]
 	assert.Equal(t, sriov.UsedVirtualFunction, selectedVfState)
 }
 
@@ -114,14 +112,12 @@ func TestNewServer_NoFreeVirtualFunctions(t *testing.T) {
 
 	vf1, vf2 := initVfs()
 	resourcePool := &sriov.NetResourcePool{
-		Resources: []*sriov.NetResource{
+		PhysicalFunctions: []*sriov.PhysicalFunction{
 			{
-				PhysicalFunction: &sriov.PhysicalFunction{
-					PCIAddress: pfPCIAddress,
-					VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
-						vf1: sriov.UsedVirtualFunction,
-						vf2: sriov.UsedVirtualFunction,
-					},
+				PCIAddress: pfPCIAddress,
+				VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
+					vf1: sriov.UsedVirtualFunction,
+					vf2: sriov.UsedVirtualFunction,
 				},
 			},
 		},
@@ -147,14 +143,12 @@ func TestNewServer_ReleaseVirtualFunctions(t *testing.T) {
 
 	vf1, vf2 := initVfs()
 	resourcePool := &sriov.NetResourcePool{
-		Resources: []*sriov.NetResource{
+		PhysicalFunctions: []*sriov.PhysicalFunction{
 			{
-				PhysicalFunction: &sriov.PhysicalFunction{
-					PCIAddress: pfPCIAddress,
-					VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
-						vf1: sriov.UsedVirtualFunction,
-						vf2: sriov.UsedVirtualFunction,
-					},
+				PCIAddress: pfPCIAddress,
+				VirtualFunctions: map[*sriov.VirtualFunction]sriov.VirtualFunctionState{
+					vf1: sriov.UsedVirtualFunction,
+					vf2: sriov.UsedVirtualFunction,
 				},
 			},
 		},
@@ -174,6 +168,6 @@ func TestNewServer_ReleaseVirtualFunctions(t *testing.T) {
 	_, err := client.Close(context.Background(), conn)
 	assert.Nil(t, err)
 
-	freedVfState := resourcePool.Resources[0].PhysicalFunction.VirtualFunctions[vf1]
+	freedVfState := resourcePool.PhysicalFunctions[0].VirtualFunctions[vf1]
 	assert.Equal(t, sriov.FreeVirtualFunction, freedVfState)
 }

--- a/pkg/sriov/types.go
+++ b/pkg/sriov/types.go
@@ -47,9 +47,9 @@ const (
 
 // NetResourcePool provides contains information about net devices
 type NetResourcePool struct {
-	HostName  string
-	Resources []*NetResource
-	lock      sync.Mutex
+	HostName          string
+	PhysicalFunctions []*PhysicalFunction
+	lock              sync.Mutex
 }
 
 // InitResourcePool configures devices, specified in provided config and initializes resource pool with that devices
@@ -132,8 +132,7 @@ func (n *NetResourcePool) SelectVirtualFunction(pfPCIAddr string) (selectedVf *V
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
-	for _, netResource := range n.Resources {
-		pf := netResource.PhysicalFunction
+	for _, pf := range n.PhysicalFunctions {
 		if pf.PCIAddress != pfPCIAddr {
 			continue
 		}
@@ -166,8 +165,7 @@ func (n *NetResourcePool) ReleaseVirtualFunction(pfPCIAddr, vfNetIfaceName strin
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
-	for _, netResource := range n.Resources {
-		pf := netResource.PhysicalFunction
+	for _, pf := range n.PhysicalFunctions {
 		if pf.PCIAddress != pfPCIAddr {
 			continue
 		}
@@ -193,8 +191,7 @@ func (n *NetResourcePool) GetFreeVirtualFunctionsInfo() *FreeVirtualFunctionsInf
 		FreeVirtualFunctions: map[string]int{},
 	}
 
-	for _, netResource := range n.Resources {
-		pf := netResource.PhysicalFunction
+	for _, pf := range n.PhysicalFunctions {
 		freeVfs := pf.GetFreeVirtualFunctionsNumber()
 		info.FreeVirtualFunctions[pf.PCIAddress] = freeVfs
 	}
@@ -202,15 +199,10 @@ func (n *NetResourcePool) GetFreeVirtualFunctionsInfo() *FreeVirtualFunctionsInf
 	return info
 }
 
-// NetResource contains information about net device
-type NetResource struct {
-	Capability       string
-	PhysicalFunction *PhysicalFunction
-}
-
 // PhysicalFunction contains information about physical function
 type PhysicalFunction struct {
 	PCIAddress               string
+	Capability               string
 	TargetPCIAddress         string
 	VirtualFunctionsCapacity int
 	NetInterfaceName         string


### PR DESCRIPTION
NetResource structure contains the following info:
``` go
type NetResource struct {
	Capability       string
	PhysicalFunction *PhysicalFunction
}
```
`Capability` is the property of `PhysicalFunction` itself, so it would be logical to move it into the `PhysicalFunction` and get rid of redundant `NetResource` to simplify `ResourcePool` structure.