### PR TITLE
Cgroup fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.4.3
-	github.com/google/uuid v1.1.2
+	github.com/google/uuid v1.2.0
 	github.com/networkservicemesh/api v0.0.0-20210218170701-1a72f1cba074
 	github.com/networkservicemesh/sdk v0.0.0-20210226095245-acdecd4599ac
 	github.com/networkservicemesh/sdk-kernel v0.0.0-20210226095937-76847e2a604b

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v0.0.0-20181024020800-521ea7b17d02/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 h1:MJG/KsmcqMwFAkh8mTnAwhyKoB+sTAnY4CACC110tbU=

--- a/pkg/networkservice/common/mechanisms/vfio/client.go
+++ b/pkg/networkservice/common/mechanisms/vfio/client.go
@@ -32,6 +32,8 @@ import (
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/vfio"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
+
+	"github.com/networkservicemesh/sdk-sriov/pkg/tools/cgroup"
 )
 
 type vfioClient struct {
@@ -56,7 +58,7 @@ func NewClient(options ...Option) networkservice.NetworkServiceClient {
 
 	if c.cgroupDir == "" {
 		var err error
-		if c.cgroupDir, err = cgroupDirPath(); err != nil {
+		if c.cgroupDir, err = cgroup.DirPath(); err != nil {
 			return injecterror.NewClient(err)
 		}
 	}

--- a/pkg/networkservice/common/mechanisms/vfio/client_test.go
+++ b/pkg/networkservice/common/mechanisms/vfio/client_test.go
@@ -43,6 +43,7 @@ import (
 
 const (
 	serverSocket = "server.socket"
+	cgroupDir    = "cgroup_dir"
 )
 
 func testServer(ctx context.Context, tmpDir string) (grpc.ClientConnInterface, error) {

--- a/pkg/sriov/sriovtest/pci_function.go
+++ b/pkg/sriov/sriovtest/pci_function.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package sriovtest provides utils for SR-IOV testing
 package sriovtest
 
 // PCIPhysicalFunction is a test data class for pcifunction.PhysicalFunction

--- a/pkg/tools/cgroup/cgroup.go
+++ b/pkg/tools/cgroup/cgroup.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build !windows
+
+package cgroup
+
+import (
+	"bufio"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+)
+
+const (
+	deviceListFileName  = "devices.list"
+	deviceAllowFileName = "devices.allow"
+	deviceDenyFileName  = "devices.deny"
+)
+
+// Cgroup represents linux devices cgroup
+type Cgroup struct {
+	Path string
+}
+
+// NewCgroups returns all cgroups matching pathPattern
+func NewCgroups(pathPattern string) (cgroups []*Cgroup, err error) {
+	var filePaths []string
+	filePaths, err = filepath.Glob(filepath.Join(pathPattern, deviceListFileName))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, filePath := range filePaths {
+		cgroups = append(cgroups, &Cgroup{Path: filepath.Dir(filePath)})
+	}
+
+	return cgroups, nil
+}
+
+// Allow allows "c major:minor rwm" for cgroup
+func (c *Cgroup) Allow(major, minor uint32) error {
+	dev := newDevice(major, minor, 'r', 'w', 'm')
+
+	return ioutil.WriteFile(filepath.Join(c.Path, deviceAllowFileName), []byte(dev.String()), 0)
+}
+
+// Deny denies "c major:minor rw" for cgroup
+func (c *Cgroup) Deny(major, minor uint32) error {
+	dev := newDevice(major, minor, 'r', 'w')
+
+	return ioutil.WriteFile(filepath.Join(c.Path, deviceDenyFileName), []byte(dev.String()), 0)
+}
+
+// IsAllowed returns if "c major:minor rwm" is allowed for cgroup
+func (c *Cgroup) IsAllowed(major, minor uint32) (bool, error) {
+	isAllowed, _, err := c.compareTo(newDevice(major, minor, 'r', 'w', 'm'))
+	return isAllowed, err
+}
+
+// IsWiderThan returns if cgroup allows wider device group than "c major:minor rwm":
+//   - "a *:minor rwm"
+//   - "a major:* rwm"
+//   - "a *:* rwm"
+//   - "c *:minor rwm"
+//   - "c major:* rwm"
+//   - "c *:* rwm"
+func (c *Cgroup) IsWiderThan(major, minor uint32) (bool, error) {
+	_, isWider, err := c.compareTo(newDevice(major, minor, 'r', 'w', 'm'))
+	return isWider, err
+}
+
+func (c *Cgroup) compareTo(dev *device) (isAllowed, isWider bool, err error) {
+	file, err := os.Open(filepath.Join(c.Path, deviceListFileName))
+	if err != nil {
+		return false, false, err
+	}
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		d, err := parseDevice(scanner.Text())
+		if err != nil {
+			return false, false, err
+		}
+
+		if reflect.DeepEqual(d, dev) {
+			isAllowed = true
+		} else if d.isWiderThan(dev) {
+			return true, true, nil
+		}
+	}
+	return isAllowed, false, nil
+}

--- a/pkg/tools/cgroup/cgroup_test.go
+++ b/pkg/tools/cgroup/cgroup_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build !windows
+
+package cgroup_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/networkservicemesh/sdk-sriov/pkg/tools/cgroup"
+)
+
+const (
+	mkdirPerm          = 0750
+	deviceListFileName = "devices.list"
+)
+
+func createCgroup(t *testing.T, path string) {
+	require.NoError(t, os.MkdirAll(path, mkdirPerm))
+
+	f, err := os.Create(filepath.Join(path, deviceListFileName))
+	require.NoError(t, err)
+	_ = f.Close()
+}
+
+func TestNewCgroups(t *testing.T) {
+	tmpDir := filepath.Join(os.TempDir(), t.Name())
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	createCgroup(t, filepath.Join(tmpDir, "a"))
+	createCgroup(t, filepath.Join(tmpDir, "b"))
+	createCgroup(t, filepath.Join(tmpDir, "c"))
+
+	cgroups, err := cgroup.NewCgroups(filepath.Join(tmpDir, "*"))
+	require.NoError(t, err)
+	require.Len(t, cgroups, 3)
+
+	require.Equal(t, filepath.Join(tmpDir, "a"), cgroups[0].Path)
+	require.Equal(t, filepath.Join(tmpDir, "b"), cgroups[1].Path)
+	require.Equal(t, filepath.Join(tmpDir, "c"), cgroups[2].Path)
+}
+
+func TestCgroup_IsWiderThan(t *testing.T) {
+	samples := []struct {
+		name   string
+		device string
+		result bool
+	}{
+		{
+			name:   "All major",
+			device: "a *:2 rwm",
+			result: true,
+		},
+		{
+			name:   "All minor",
+			device: "a 1:* rwm",
+			result: true,
+		},
+		{
+			name:   "Char major",
+			device: "c *:2 rwm",
+			result: true,
+		},
+		{
+			name:   "Char minor",
+			device: "c 1:* rwm",
+			result: true,
+		},
+		{
+			name:   "All",
+			device: "a 1:2 rwm",
+			result: true,
+		},
+		{
+			name:   "Char",
+			device: "c 1:2 rwm",
+			result: false,
+		},
+		{
+			name:   "Block",
+			device: "b *:* rwm",
+			result: false,
+		},
+	}
+
+	tmpDir := filepath.Join(os.TempDir(), t.Name())
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	createCgroup(t, tmpDir)
+
+	cgroups, err := cgroup.NewCgroups(tmpDir)
+	require.NoError(t, err)
+
+	cg := cgroups[0]
+
+	for i := range samples {
+		sample := samples[i]
+		t.Run(sample.name, func(t *testing.T) {
+			err := ioutil.WriteFile(filepath.Join(tmpDir, deviceListFileName), []byte(sample.device), 0)
+			require.NoError(t, err)
+
+			isWider, err := cg.IsWiderThan(1, 2)
+			require.NoError(t, err)
+			require.Equal(t, sample.result, isWider)
+		})
+	}
+}

--- a/pkg/tools/cgroup/device.go
+++ b/pkg/tools/cgroup/device.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build !windows
+
+package cgroup
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type device struct {
+	Type  string
+	Major string
+	Minor string
+	Modes map[rune]struct{}
+}
+
+func newDevice(major, minor uint32, modes ...rune) *device {
+	d := &device{
+		Type:  "c",
+		Major: strconv.FormatUint(uint64(major), 10),
+		Minor: strconv.FormatUint(uint64(minor), 10),
+		Modes: make(map[rune]struct{}),
+	}
+
+	for _, mode := range modes {
+		d.Modes[mode] = struct{}{}
+	}
+
+	return d
+}
+
+var devicePattern = regexp.MustCompile("(?P<type>[abc]) (?P<major>[*0-9]+):(?P<minor>[*0-9]+) (?P<mode>[rwm]+)")
+
+func parseDevice(s string) (*device, error) {
+	if !devicePattern.MatchString(s) {
+		return nil, errors.Errorf("invalid device string: %s", s)
+	}
+
+	split := devicePattern.FindAllStringSubmatch(s, -1)[0]
+
+	d := &device{
+		Type:  split[devicePattern.SubexpIndex("type")],
+		Major: split[devicePattern.SubexpIndex("major")],
+		Minor: split[devicePattern.SubexpIndex("minor")],
+		Modes: make(map[rune]struct{}),
+	}
+
+	for _, mode := range split[devicePattern.SubexpIndex("mode")] {
+		d.Modes[mode] = struct{}{}
+	}
+
+	return d, nil
+}
+
+func (d *device) String() string {
+	sb := new(strings.Builder)
+
+	sb.WriteString(d.Type)
+	sb.WriteString(" ")
+
+	sb.WriteString(d.Major)
+	sb.WriteString(":")
+	sb.WriteString(d.Minor)
+	sb.WriteString(" ")
+
+	for mode := range d.Modes {
+		sb.WriteRune(mode)
+	}
+	sb.WriteRune('\n')
+
+	return sb.String()
+}
+
+func (d *device) isWiderThan(other *device) (isWider bool) {
+	switch d.Type {
+	case other.Type:
+	case "a":
+		isWider = true
+	default:
+		return false
+	}
+
+	switch {
+	case d.Major == other.Major:
+	case d.Major == "*":
+		isWider = true
+	default:
+		return false
+	}
+
+	switch {
+	case d.Minor == other.Minor:
+	case d.Minor == "*":
+		isWider = true
+	default:
+		return false
+	}
+
+	for mode := range other.Modes {
+		if _, ok := d.Modes[mode]; !ok {
+			return false
+		}
+	}
+	if len(d.Modes) > len(other.Modes) {
+		isWider = true
+	}
+
+	return isWider
+}

--- a/pkg/tools/cgroup/doc.go
+++ b/pkg/tools/cgroup/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -14,10 +14,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vfio_test
-
-const (
-	vfioDevice       = "vfio"
-	iommuGroup       = 1
-	iommuGroupString = "1"
-)
+// Package cgroup provides utilities for linux devices cgroups
+package cgroup

--- a/pkg/tools/cgroup/fake_cgroup.go
+++ b/pkg/tools/cgroup/fake_cgroup.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build !windows
+
+package cgroup
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	mkdirPerm = 0750
+)
+
+// NewFakeCgroup creates and returns a new cgroup for testing with some k8s default devices allowed.
+func NewFakeCgroup(ctx context.Context, path string) (*Cgroup, error) {
+	cg, deviceSupplier, err := newFakeCgroup(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = deviceSupplier("c 136:* rwm"); err != nil {
+		return nil, err
+	}
+	if err = deviceSupplier("c *:* m"); err != nil {
+		return nil, err
+	}
+	if err = deviceSupplier("b *:* m"); err != nil {
+		return nil, err
+	}
+
+	return cg, err
+}
+
+// NewFakeWideCgroup creates and returns a new cgroup for testing with "a *:* rwm" allowed
+func NewFakeWideCgroup(ctx context.Context, path string) (*Cgroup, error) {
+	cg, deviceSupplier, err := newFakeCgroup(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = deviceSupplier("a *:* rwm"); err != nil {
+		return nil, err
+	}
+
+	return cg, nil
+}
+
+func newFakeCgroup(ctx context.Context, path string) (*Cgroup, supplierFunc, error) {
+	if err := os.MkdirAll(path, mkdirPerm); err != nil {
+		return nil, nil, err
+	}
+	go func() {
+		<-ctx.Done()
+		_ = os.RemoveAll(path)
+	}()
+
+	var lock sync.Mutex
+	cgStub := new(fakeCgroupDevices)
+
+	deviceSupplier := outputFileAPI(filepath.Join(path, deviceListFileName))
+	if err := deviceSupplier(""); err != nil {
+		return nil, nil, err
+	}
+
+	if err := inputFileAPI(ctx, filepath.Join(path, deviceAllowFileName), func(s string) {
+		lock.Lock()
+		defer lock.Unlock()
+
+		dev, _ := parseDevice(s)
+		cgStub.allow(dev)
+
+		_ = deviceSupplier(cgStub.String())
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	if err := inputFileAPI(ctx, filepath.Join(path, deviceDenyFileName), func(s string) {
+		lock.Lock()
+		defer lock.Unlock()
+
+		dev, _ := parseDevice(s)
+		cgStub.deny(dev)
+
+		_ = deviceSupplier(cgStub.String())
+	}); err != nil {
+		return nil, nil, err
+	}
+
+	cgroups, err := NewCgroups(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(cgroups) != 1 {
+		return nil, nil, errors.Errorf("expected exactly 1 cgroup for path: %s", path)
+	}
+
+	return cgroups[0], deviceSupplier, nil
+}
+
+type fakeCgroupDevices struct {
+	devices []*device
+}
+
+func (s *fakeCgroupDevices) String() string {
+	sb := new(strings.Builder)
+	for _, dev := range s.devices {
+		sb.WriteString(dev.String())
+	}
+	return sb.String()
+}
+
+func (s *fakeCgroupDevices) allow(dev *device) {
+	for i := 0; i < len(s.devices); {
+		d := s.devices[i]
+
+		if reflect.DeepEqual(d, dev) || d.isWiderThan(dev) {
+			return
+		}
+
+		if dev.isWiderThan(d) {
+			s.devices = append(s.devices[:i], s.devices[i+1:]...)
+			continue
+		}
+
+		i++
+	}
+	s.devices = append(s.devices, dev)
+}
+
+func (s *fakeCgroupDevices) deny(dev *device) {
+	for i := 0; i < len(s.devices); {
+		d := s.devices[i]
+
+		if reflect.DeepEqual(d, dev) || dev.isWiderThan(d) {
+			s.devices = append(s.devices[:i], s.devices[i+1:]...)
+			continue
+		}
+
+		if d.isWiderThan(dev) {
+			for mode := range dev.Modes {
+				delete(d.Modes, mode)
+			}
+			if len(d.Modes) == 0 {
+				s.devices = append(s.devices[:i], s.devices[i+1:]...)
+				continue
+			}
+		}
+
+		i++
+	}
+}

--- a/pkg/tools/cgroup/file_api.go
+++ b/pkg/tools/cgroup/file_api.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -16,8 +16,7 @@
 
 //+build !windows
 
-// Package sriovtest provides utils for SR-IOV testing
-package sriovtest
+package cgroup
 
 import (
 	"bufio"
@@ -29,13 +28,12 @@ import (
 )
 
 const (
-	mkfifoPerm = 0666
+	createPerm = 0666
 )
 
-// InputFileAPI calls consumer when someone writes into filePath File
-func InputFileAPI(ctx context.Context, filePath string, consumer func(string)) error {
+func inputFileAPI(ctx context.Context, filePath string, consumer func(string)) error {
 	_ = os.Remove(filePath)
-	err := unix.Mkfifo(filePath, mkfifoPerm)
+	err := unix.Mkfifo(filePath, createPerm)
 	if err != nil {
 		return err
 	}
@@ -76,10 +74,11 @@ func readFile(ctx context.Context, file *os.File) <-chan string {
 	return ch
 }
 
-// OutputFileAPI rewrites filePath File every time supplier called
-func OutputFileAPI(filePath string) (supplier func(string) error) {
+type supplierFunc func(s string) error
+
+func outputFileAPI(filePath string) (supplier supplierFunc) {
 	supplier = func(data string) error {
-		return ioutil.WriteFile(filePath, []byte(data), 0)
+		return ioutil.WriteFile(filePath, []byte(data), createPerm)
 	}
 	return supplier
 }


### PR DESCRIPTION
# Issues
1. If empty VFIO mechanism was passed to the VFIO client chain element it does nothing.
2. If NSC provides incorrect cgroup dir, it can lead to invalid device deprecations on the same cluster node and so node falure.
# Solution
1. Fill passed mechanism with cgroup dir if it exists.
2. Deny devices with care:
   1. Don't deny device if cgroup already provides wider allows.
   2. Deny device for `rw`, not for `rwm` to prevent collisions with k8s device allows.