### PR TITLE
Fix issue with forwarder chain healing

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -163,7 +163,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/pkg/networkservice/chains/xconnectns/server.go
+++ b/pkg/networkservice/chains/xconnectns/server.go
@@ -84,7 +84,7 @@ func NewServer(
 	clientURL *url.URL,
 	clientDialOptions ...grpc.DialOption,
 ) endpoint.Endpoint {
-	rv := sriovServer{}
+	rv := new(sriovServer)
 
 	connectChainFactory := func(class string) networkservice.NetworkServiceServer {
 		return chain.NewNetworkServiceServer(


### PR DESCRIPTION
## Issue
Closes #144.

## Solution
Forwarder should pass reference of `sriovServer` to heal server instead of copy.