### PR TITLE
Update to sdk manually

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.2.0
 	github.com/networkservicemesh/api v0.0.0-20210417193417-dd329f8d6b7a
-	github.com/networkservicemesh/sdk v0.0.0-20210423102713-5c10e501f885
+	github.com/networkservicemesh/sdk v0.0.0-20210426082457-79914fd80cf9
 	github.com/networkservicemesh/sdk-kernel v0.0.0-20210419133626-2fda82526537
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.2.0
 	github.com/networkservicemesh/api v0.0.0-20210417193417-dd329f8d6b7a
-	github.com/networkservicemesh/sdk v0.0.0-20210419133331-3cc35eb3f979
+	github.com/networkservicemesh/sdk v0.0.0-20210423102713-5c10e501f885
 	github.com/networkservicemesh/sdk-kernel v0.0.0-20210419133626-2fda82526537
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/OneOfOne/xxhash v1.2.3 h1:wS8NNaIgtzapuArKIAjsyXtEN/IUjQkbw90xszUdS40
 github.com/OneOfOne/xxhash v1.2.3/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/armon/go-metrics v0.0.0-20190430140413-ec5e00d3c878/go.mod h1:3AMJUQhVx52RsWOnlkpikZr01T/yAVN2gn0861vByNg=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
@@ -115,8 +116,9 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nats-io/stan.go v0.6.0/go.mod h1:eIcD5bi3pqbHT/xIIvXMwvzXYElgouBvaVRftaE+eac=
 github.com/networkservicemesh/api v0.0.0-20210417193417-dd329f8d6b7a h1:BakXE3Zu+KLMYEgwcfL3zsff5J1DxCt/rI60x6KU5Q4=
 github.com/networkservicemesh/api v0.0.0-20210417193417-dd329f8d6b7a/go.mod h1:B6meq/SWjWR6bGXZdXPfbOeaBK+T1JayLdtEJQCsXKU=
-github.com/networkservicemesh/sdk v0.0.0-20210419133331-3cc35eb3f979 h1:m4IQWHsYktM8W5Z/YUYmdGDIehZcB2OWiggx82RGy0g=
 github.com/networkservicemesh/sdk v0.0.0-20210419133331-3cc35eb3f979/go.mod h1:Ur41JD2nQvG58Gc1Ppvdki3tB9VPVZTOl78MW/bYUBM=
+github.com/networkservicemesh/sdk v0.0.0-20210423102713-5c10e501f885 h1:ErGxMtNChhiqUQw52n6n55D33AZPljrFpAfcMgfUkEM=
+github.com/networkservicemesh/sdk v0.0.0-20210423102713-5c10e501f885/go.mod h1:Ur41JD2nQvG58Gc1Ppvdki3tB9VPVZTOl78MW/bYUBM=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20210419133626-2fda82526537 h1:q7H7wJ/5dkxuSr6QQOY5G4Yu1ihWhNFTeVFSlzQOZSQ=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20210419133626-2fda82526537/go.mod h1:b5FN507EBg8JSa5hLFH/VUYnUwtQ3QhX+hJIMZwQ8vQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/networkservicemesh/api v0.0.0-20210417193417-dd329f8d6b7a/go.mod h1:B
 github.com/networkservicemesh/sdk v0.0.0-20210419133331-3cc35eb3f979/go.mod h1:Ur41JD2nQvG58Gc1Ppvdki3tB9VPVZTOl78MW/bYUBM=
 github.com/networkservicemesh/sdk v0.0.0-20210423102713-5c10e501f885 h1:ErGxMtNChhiqUQw52n6n55D33AZPljrFpAfcMgfUkEM=
 github.com/networkservicemesh/sdk v0.0.0-20210423102713-5c10e501f885/go.mod h1:Ur41JD2nQvG58Gc1Ppvdki3tB9VPVZTOl78MW/bYUBM=
+github.com/networkservicemesh/sdk v0.0.0-20210426082457-79914fd80cf9 h1:+V5y04oxEV1LPxwFAX9OkLWGBGaQ3nV5cpK843n/HoY=
+github.com/networkservicemesh/sdk v0.0.0-20210426082457-79914fd80cf9/go.mod h1:Ur41JD2nQvG58Gc1Ppvdki3tB9VPVZTOl78MW/bYUBM=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20210419133626-2fda82526537 h1:q7H7wJ/5dkxuSr6QQOY5G4Yu1ihWhNFTeVFSlzQOZSQ=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20210419133626-2fda82526537/go.mod h1:b5FN507EBg8JSa5hLFH/VUYnUwtQ3QhX+hJIMZwQ8vQ=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,6 @@ github.com/nats-io/stan.go v0.6.0/go.mod h1:eIcD5bi3pqbHT/xIIvXMwvzXYElgouBvaVRf
 github.com/networkservicemesh/api v0.0.0-20210417193417-dd329f8d6b7a h1:BakXE3Zu+KLMYEgwcfL3zsff5J1DxCt/rI60x6KU5Q4=
 github.com/networkservicemesh/api v0.0.0-20210417193417-dd329f8d6b7a/go.mod h1:B6meq/SWjWR6bGXZdXPfbOeaBK+T1JayLdtEJQCsXKU=
 github.com/networkservicemesh/sdk v0.0.0-20210419133331-3cc35eb3f979/go.mod h1:Ur41JD2nQvG58Gc1Ppvdki3tB9VPVZTOl78MW/bYUBM=
-github.com/networkservicemesh/sdk v0.0.0-20210423102713-5c10e501f885 h1:ErGxMtNChhiqUQw52n6n55D33AZPljrFpAfcMgfUkEM=
-github.com/networkservicemesh/sdk v0.0.0-20210423102713-5c10e501f885/go.mod h1:Ur41JD2nQvG58Gc1Ppvdki3tB9VPVZTOl78MW/bYUBM=
 github.com/networkservicemesh/sdk v0.0.0-20210426082457-79914fd80cf9 h1:+V5y04oxEV1LPxwFAX9OkLWGBGaQ3nV5cpK843n/HoY=
 github.com/networkservicemesh/sdk v0.0.0-20210426082457-79914fd80cf9/go.mod h1:Ur41JD2nQvG58Gc1Ppvdki3tB9VPVZTOl78MW/bYUBM=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20210419133626-2fda82526537 h1:q7H7wJ/5dkxuSr6QQOY5G4Yu1ihWhNFTeVFSlzQOZSQ=

--- a/pkg/networkservice/common/mechanisms/vfio/client.go
+++ b/pkg/networkservice/common/mechanisms/vfio/client.go
@@ -59,7 +59,7 @@ func NewClient(options ...Option) networkservice.NetworkServiceClient {
 	if c.cgroupDir == "" {
 		var err error
 		if c.cgroupDir, err = cgroup.DirPath(); err != nil {
-			return injecterror.NewClient(err)
+			return injecterror.NewClient(injecterror.WithError(err))
 		}
 	}
 


### PR DESCRIPTION
## Motivation

NSMBot couldn't update sdk-sriov due to `injecterror` API has changed.

Closes https://github.com/networkservicemesh/sdk-sriov/pull/156