### PR TITLE
add ToEnv into pool

### DIFF
--- a/pkg/sriov/token/pool.go
+++ b/pkg/sriov/token/pool.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/sdk-sriov/pkg/sriov/config"
+	tokenenv "github.com/networkservicemesh/sdk-sriov/pkg/tools/tokens"
 )
 
 const (
@@ -314,4 +315,9 @@ func (p *Pool) stopUsing(id string) error {
 	}
 
 	return nil
+}
+
+// ToEnv returns a (name, value) pair to store given tokens into the environment variable
+func (p *Pool) ToEnv(tokenName string, tokenIDs []string) (name, value string) {
+	return tokenenv.ToEnv(tokenName, tokenIDs)
 }

--- a/pkg/sriov/token/pool.go
+++ b/pkg/sriov/token/pool.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2021 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/pkg/sriov/token/pool_test.go
+++ b/pkg/sriov/token/pool_test.go
@@ -108,6 +108,16 @@ func TestPool_Restore(t *testing.T) {
 	require.Equal(t, tokens, p.Tokens())
 }
 
+func TestPool_ToEnv(t *testing.T) {
+	cfg, err := config.ReadConfig(context.TODO(), configFileName)
+	require.NoError(t, err)
+
+	p := token.NewPool(cfg)
+	name, value := p.ToEnv("name", []string{"1", "2", "3"})
+	require.Equal(t, "NSM_SRIOV_TOKENS_name", name)
+	require.Equal(t, "1,2,3", value)
+}
+
 func countTrue(m map[string]bool) (count int) {
 	for _, v := range m {
 		if v {

--- a/pkg/sriov/token/pool_test.go
+++ b/pkg/sriov/token/pool_test.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2021 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
adds ToEnv method under Pool so that [device plugin server in sdk-k8s](https://github.com/networkservicemesh/sdk-k8s/pull/155) should not have compile time dependency on sdk-sriov repository.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>