### PR TITLE
[sdk-vpp#314] Use token ID key from api

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,3 +166,7 @@ issues:
   exclude-use-default: false
   max-issues-per-linter: 0
   max-same-issues: 0
+  exclude-rules:
+    - path: ".*_test.go"
+      linters:
+        - gosec

--- a/pkg/networkservice/common/resourcepool/common.go
+++ b/pkg/networkservice/common/resourcepool/common.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Nordix Foundation.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,20 +24,16 @@ import (
 	"context"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/common"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/vfio"
 	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/vfconfig"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
-	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/sdk-sriov/pkg/sriov"
 	"github.com/networkservicemesh/sdk-sriov/pkg/sriov/config"
-)
-
-const (
-	// TokenIDKey is a token ID mechanism parameter key
-	TokenIDKey = "tokenID" // TODO: move to api
 )
 
 // PCIPool is a pci.Pool interface

--- a/pkg/networkservice/common/resourcepool/server_test.go
+++ b/pkg/networkservice/common/resourcepool/server_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/common"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/vfio"
 	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/vfconfig"
@@ -50,6 +51,7 @@ const (
 	configFileName            = "config.yml"
 	pf2PciAddr                = "0000:00:02.0"
 	vf2KernelDriver           = "vf-2-driver"
+	tokenID                   = "sriov-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 )
 
 type sample struct {
@@ -139,7 +141,7 @@ func TestResourcePoolServer_Request(t *testing.T) {
 
 			// 1. Request
 
-			resourcePool.mock.On("Select", "1", sample.driverType).
+			resourcePool.mock.On("Select", tokenID, sample.driverType).
 				Return(pfs[pf2PciAddr].Vfs[1].Addr, nil)
 
 			ctx := context.TODO()
@@ -149,7 +151,7 @@ func TestResourcePoolServer_Request(t *testing.T) {
 					Mechanism: &networkservice.Mechanism{
 						Type: sample.mechanism,
 						Parameters: map[string]string{
-							resourcepool.TokenIDKey: "1",
+							common.DeviceTokenIDKey: tokenID,
 						},
 					},
 				},

--- a/pkg/networkservice/common/token/client.go
+++ b/pkg/networkservice/common/token/client.go
@@ -31,9 +31,9 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/common"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 
-	"github.com/networkservicemesh/sdk-sriov/pkg/networkservice/common/resourcepool"
 	"github.com/networkservicemesh/sdk-sriov/pkg/tools/tokens"
 )
 
@@ -70,7 +70,7 @@ func (c *tokenClient) Request(ctx context.Context, request *networkservice.Netwo
 				if mech.Parameters == nil {
 					mech.Parameters = map[string]string{}
 				}
-				mech.Parameters[resourcepool.TokenIDKey] = tokenID
+				mech.Parameters[common.DeviceTokenIDKey] = tokenID
 			}
 		}
 	}

--- a/pkg/networkservice/common/token/client_test.go
+++ b/pkg/networkservice/common/token/client_test.go
@@ -26,20 +26,21 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/networkservicemesh/api/pkg/api/networkservice"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	"github.com/networkservicemesh/sdk-sriov/pkg/networkservice/common/resourcepool"
+	"github.com/networkservicemesh/api/pkg/api/networkservice"
+	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/common"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
+	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
+
 	"github.com/networkservicemesh/sdk-sriov/pkg/networkservice/common/token"
 	"github.com/networkservicemesh/sdk-sriov/pkg/tools/tokens"
 )
 
 const (
 	tokenName          = "service.domain/10G"
-	tokenID            = "1"
+	tokenID            = "sriov-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 	sriovTokenLabel    = "sriovToken"
 	serviceDomainLabel = "serviceDomain"
 	serviceDomain      = "service.domain"
@@ -89,7 +90,7 @@ func (c *validateClient) Request(ctx context.Context, request *networkservice.Ne
 	}, request.GetConnection().GetLabels())
 
 	for _, mech := range request.GetMechanismPreferences() {
-		require.Equal(c.t, tokenID, mech.GetParameters()[resourcepool.TokenIDKey])
+		require.Equal(c.t, tokenID, mech.GetParameters()[common.DeviceTokenIDKey])
 	}
 
 	return next.Client(ctx).Request(ctx, request, opts...)

--- a/pkg/networkservice/common/token/server.go
+++ b/pkg/networkservice/common/token/server.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 Nordix Foundation.
 //
+// Copyright (c) 2021 Doc.ai and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,11 +25,11 @@ import (
 	"os"
 
 	"github.com/golang/protobuf/ptypes/empty"
+
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	"github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/kernel"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/next"
 
-	"github.com/networkservicemesh/sdk-sriov/pkg/networkservice/common/resourcepool"
 	"github.com/networkservicemesh/sdk-sriov/pkg/tools/tokens"
 )
 
@@ -48,10 +50,9 @@ func NewServer(tokenKey string) networkservice.NetworkServiceServer {
 
 func (s *tokenServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
 	var tokenID string
-	if mechanism := kernel.ToMechanism(request.GetConnection().GetMechanism()); mechanism != nil || mechanism.Parameters[resourcepool.TokenIDKey] == "" {
-		tokenID = s.config.assign(s.tokenName, request.GetConnection())
-		if tokenID != "" {
-			mechanism.Parameters[resourcepool.TokenIDKey] = tokenID
+	if mechanism := kernel.ToMechanism(request.GetConnection().GetMechanism()); mechanism != nil || mechanism.GetDeviceTokenID() == "" {
+		if tokenID = s.config.assign(s.tokenName, request.GetConnection()); tokenID != "" {
+			mechanism.SetDeviceTokenID(tokenID)
 		}
 	}
 

--- a/pkg/sriov/token/pool.go
+++ b/pkg/sriov/token/pool.go
@@ -23,11 +23,10 @@ import (
 	"path"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/sdk-sriov/pkg/sriov/config"
-	tokenenv "github.com/networkservicemesh/sdk-sriov/pkg/tools/tokens"
+	sriovtokens "github.com/networkservicemesh/sdk-sriov/pkg/tools/tokens"
 )
 
 const (
@@ -81,7 +80,7 @@ func NewPool(cfg *config.Config) *Pool {
 				name := path.Join(serviceDomain, capability)
 				for i := 0; i < len(pfCfg.VirtualFunctions); i++ {
 					tok := &token{
-						id:    uuid.New().String(),
+						id:    sriovtokens.NewTokenID(),
 						name:  name,
 						state: free,
 					}
@@ -321,5 +320,5 @@ func (p *Pool) stopUsing(id string) error {
 
 // ToEnv returns a (name, value) pair to store given tokens into the environment variable
 func (p *Pool) ToEnv(tokenName string, tokenIDs []string) (name, value string) {
-	return tokenenv.ToEnv(tokenName, tokenIDs)
+	return sriovtokens.ToEnv(tokenName, tokenIDs)
 }

--- a/pkg/tools/tokens/tokens.go
+++ b/pkg/tools/tokens/tokens.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
 // Copyright (c) 2021 Nordix Foundation.
 //
@@ -22,11 +22,14 @@ package tokens
 import (
 	"fmt"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 const (
 	// EnvPrefix sriov token env name prefix
-	EnvPrefix = "NSM_SRIOV_TOKENS_"
+	EnvPrefix   = "NSM_SRIOV_TOKENS_"
+	sriovPrevix = "sriov-"
 )
 
 // ToEnv returns a (name, value) pair to store given tokens into the environment variable
@@ -45,4 +48,16 @@ func FromEnv(envs []string) map[string][]string {
 		tokens[nameIDs[0]] = strings.Split(nameIDs[1], ",")
 	}
 	return tokens
+}
+
+// NewTokenID returns a new SR-IOV token ID
+func NewTokenID() string {
+	return sriovPrevix + uuid.New().String()
+}
+
+var tokenIDLen = len(NewTokenID())
+
+// IsTokenID returns if given string is a SR-IOV token ID
+func IsTokenID(s string) bool {
+	return strings.HasPrefix(s, sriovPrevix) && len(s) == tokenIDLen
 }


### PR DESCRIPTION
## Description
Starts SR-IOV token ID mechanism parameter from `api`.

Depends on https://github.com/networkservicemesh/api/pull/110.

## Issue link
Needed for networkservicemesh/sdk-vpp#314.

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [x] ~Added unit testing to cover~ Covered by existing unit testing
- [x] Tested manually
- [ ] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [ ] New functionallity
- [ ] Documentation
- [x] Refactoring
- [ ] CI
