### PR TITLE
update sriov xconnect endpoint to latest sdk-kernel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/golang/protobuf v1.4.3
 	github.com/google/uuid v1.2.0
 	github.com/networkservicemesh/api v1.0.1-0.20210811070028-10403c0f20c8
-	github.com/networkservicemesh/sdk v0.5.1-0.20210817132536-a91779d763cf
-	github.com/networkservicemesh/sdk-kernel v0.0.0-20210817133308-b603cd5858f8
+	github.com/networkservicemesh/sdk v0.5.1-0.20210823074050-b1370083e4e1
+	github.com/networkservicemesh/sdk-kernel v0.0.0-20210823074523-3b5c4bb395ad
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/goleak v1.1.10

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,10 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nats-io/stan.go v0.6.0/go.mod h1:eIcD5bi3pqbHT/xIIvXMwvzXYElgouBvaVRftaE+eac=
 github.com/networkservicemesh/api v1.0.1-0.20210811070028-10403c0f20c8 h1:kr2/dA/ktBgnChorXBwjn7fdpRKB+eJI2xCPNCGt3ws=
 github.com/networkservicemesh/api v1.0.1-0.20210811070028-10403c0f20c8/go.mod h1:B6meq/SWjWR6bGXZdXPfbOeaBK+T1JayLdtEJQCsXKU=
-github.com/networkservicemesh/sdk v0.5.1-0.20210817132536-a91779d763cf h1:1/Nvt7Cd7I+uYJsFrYn7irJd72DTNMQ31PzJRjcnK4A=
-github.com/networkservicemesh/sdk v0.5.1-0.20210817132536-a91779d763cf/go.mod h1:LmMlte3Erm5n+O5rJoVgcpqgYd18aVEefgezfCOKU8A=
-github.com/networkservicemesh/sdk-kernel v0.0.0-20210817133308-b603cd5858f8 h1:GbBzmEXeAvGFwKftkpU1Vvehm9ecYE0whRb+k4sftNw=
-github.com/networkservicemesh/sdk-kernel v0.0.0-20210817133308-b603cd5858f8/go.mod h1:qOQD7FJfpgDtExG7Xp9s3RrXvLq7YjSgokTv7jHOUWE=
+github.com/networkservicemesh/sdk v0.5.1-0.20210823074050-b1370083e4e1 h1:0gykIPki523ML/GE80FSKC1/zuTAfm/jeDVkgW3vJXY=
+github.com/networkservicemesh/sdk v0.5.1-0.20210823074050-b1370083e4e1/go.mod h1:LmMlte3Erm5n+O5rJoVgcpqgYd18aVEefgezfCOKU8A=
+github.com/networkservicemesh/sdk-kernel v0.0.0-20210823074523-3b5c4bb395ad h1:Q6TC0jylztH/skzwGaai0tRFxrx/8vE/MyQZWrarW+w=
+github.com/networkservicemesh/sdk-kernel v0.0.0-20210823074523-3b5c4bb395ad/go.mod h1:8xDp7/M70MZmNg4tMWSU6Q9EXnrlImp6l3Dro7zCVAM=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=

--- a/pkg/networkservice/chains/xconnectns/server.go
+++ b/pkg/networkservice/chains/xconnectns/server.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2020-2021 Doc.ai and/or its affiliates.
 //
+// Copyright (c) 2021 Nordix Foundation.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,8 +36,6 @@ import (
 	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/connectioncontextkernel"
 	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/ethernetcontext"
 	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/inject"
-	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/netns"
-	"github.com/networkservicemesh/sdk-kernel/pkg/kernel/networkservice/rename"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/endpoint"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/clienturl"
@@ -114,8 +114,6 @@ func NewServer(
 			mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
 				kernel.MECHANISM: chain.NewNetworkServiceServer(
 					resourcepool.NewServer(sriov.KernelDriver, resourceLock, pciPool, resourcePool, sriovConfig),
-					rename.NewServer(),
-					inject.NewServer(),
 				),
 				vfiomech.MECHANISM: chain.NewNetworkServiceServer(
 					resourcepool.NewServer(sriov.VFIOPCIDriver, resourceLock, pciPool, resourcePool, sriovConfig),
@@ -126,9 +124,7 @@ func NewServer(
 		connectChainFactory(cls.REMOTE),
 		// we setup VF ethernet context using PF interface, so we do it in the forwarder net NS
 		ethernetcontext.NewVFServer(),
-		// now setup VF interface, so we do it in the client net NS
-		netns.NewServer(),
-		rename.NewServer(),
+		inject.NewServer(),
 		connectioncontextkernel.NewServer(),
 	)
 


### PR DESCRIPTION
Fixes ci error at [https://github.com/networkservicemesh/sdk-kernel/runs/3397889112?check_suite_focus=true](https://github.com/networkservicemesh/sdk-kernel/runs/3397889112?check_suite_focus=true)

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>