### PR TITLE
inject vf into client before connection established

### DIFF
--- a/pkg/networkservice/chains/xconnectns/server.go
+++ b/pkg/networkservice/chains/xconnectns/server.go
@@ -121,11 +121,11 @@ func NewServer(
 				),
 			}),
 		),
-		connectChainFactory(cls.REMOTE),
 		// we setup VF ethernet context using PF interface, so we do it in the forwarder net NS
 		ethernetcontext.NewVFServer(),
 		inject.NewServer(),
 		connectioncontextkernel.NewServer(),
+		connectChainFactory(cls.REMOTE),
 	)
 
 	rv.Endpoint = endpoint.NewServer(ctx, tokenGenerator,


### PR DESCRIPTION
this injects and configures vf into client container before xconnect endpoint makes service request to actual endpoint. otherwise, vf is not injected into client due to connection established check in the inject chain element.

fixes current ci issue with sriov forwarder. 

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>