### PR TITLE
Migrate from GOPROXY to GONOPROXY to ensure ci updates to latest nsm modules

### DIFF
--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -68,8 +68,8 @@ jobs:
       - name: Update ${{ github.repository }} locally
         working-directory: networkservicemesh/${{ matrix.repository }}
         run: |
-          GOPROXY=direct go get -u github.com/${{ github.repository }}@main
-          GOPROXY=direct go get -u github.com/networkservicemesh/sdk@${{ steps.get-sdk-version.outputs.value }}
+          GONOPROXY='github.com/networkservicemesh/*' go get -u github.com/${{ github.repository }}@main
+          GONOPROXY='github.com/networkservicemesh/*' go get -u github.com/networkservicemesh/sdk@${{ steps.get-sdk-version.outputs.value }}
           go mod tidy
           git diff
       - name: Push update to the ${{ matrix.repository }}


### PR DESCRIPTION
We've been using GOPROXY=direct in our ci to ensure that
update-repositories updates to the latest from github.

This also has the side effect of pulling directly from repos
for *all* dependencies, including some that are somewhat unstable
and intermittently unavailable

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
