### PR TITLE
graceful kernel vf handling for vlan trunking

### DIFF
--- a/pkg/networkservice/common/resourcepool/config.yml
+++ b/pkg/networkservice/common/resourcepool/config.yml
@@ -1,6 +1,7 @@
 ---
 physicalFunctions:
   0000:00:01.0:
+    skipDriverCheck: true
     pfKernelDriver: pf-1-driver
     vfKernelDriver: vf-1-driver
     capabilities:
@@ -14,6 +15,7 @@ physicalFunctions:
       - address: 0000:00:01.2
         iommuGroup: 1
   0000:00:02.0:
+    skipDriverCheck: true
     pfKernelDriver: pf-2-driver
     vfKernelDriver: vf-2-driver
     capabilities:

--- a/pkg/sriov/config/config.go
+++ b/pkg/sriov/config/config.go
@@ -56,7 +56,7 @@ type PhysicalFunction struct {
 	VFKernelDriver   string             `yaml:"vfKernelDriver"`
 	Capabilities     []string           `yaml:"capabilities"`
 	ServiceDomains   []string           `yaml:"serviceDomains"`
-	SkipDriverCheck  string             `default:"false" yaml:"skipDriverCheck"`
+	SkipDriverCheck  string             `yaml:"skipDriverCheck"`
 	VirtualFunctions []*VirtualFunction `yaml:"virtualFunctions"`
 }
 

--- a/pkg/sriov/config/config.go
+++ b/pkg/sriov/config/config.go
@@ -20,6 +20,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"
@@ -55,6 +56,7 @@ type PhysicalFunction struct {
 	VFKernelDriver   string             `yaml:"vfKernelDriver"`
 	Capabilities     []string           `yaml:"capabilities"`
 	ServiceDomains   []string           `yaml:"serviceDomains"`
+	SkipDriverCheck  string             `default:"false" yaml:"skipDriverCheck"`
 	VirtualFunctions []*VirtualFunction `yaml:"virtualFunctions"`
 }
 
@@ -83,6 +85,9 @@ func (pf *PhysicalFunction) String() string {
 	}
 	_, _ = sb.WriteString(strings.Join(strs, " "))
 	_, _ = sb.WriteString("]")
+
+	_, _ = sb.WriteString(" SkipDriverCheck:")
+	_, _ = sb.WriteString(pf.SkipDriverCheck)
 
 	_, _ = sb.WriteString("}")
 	return sb.String()
@@ -115,6 +120,9 @@ func ReadConfig(ctx context.Context, configFile string) (*Config, error) {
 		}
 		if len(pfCfg.ServiceDomains) == 0 {
 			return nil, errors.Errorf("%s has no ServiceDomains set", pciAddr)
+		}
+		if _, err := strconv.ParseBool(pfCfg.SkipDriverCheck); err != nil {
+			return nil, errors.Errorf("%s has invalid SkipDriverCheck set", pciAddr)
 		}
 	}
 

--- a/pkg/sriov/config/config.yml
+++ b/pkg/sriov/config/config.yml
@@ -1,6 +1,7 @@
 ---
 physicalFunctions:
   0000:01:00.0:
+    skipDriverCheck: true
     pfKernelDriver: pf-driver
     vfKernelDriver: vf-driver
     capabilities:
@@ -14,6 +15,7 @@ physicalFunctions:
       - address: 0000:01:00.2
         iommuGroup: 2
   0000:02:00.0:
+    skipDriverCheck: true
     pfKernelDriver: pf-driver
     vfKernelDriver: vf-driver
     capabilities:

--- a/pkg/sriov/config/config_test.go
+++ b/pkg/sriov/config/config_test.go
@@ -41,6 +41,7 @@ const (
 	vf21PciAddr     = "0000:02:00.1"
 	vf22PciAddr     = "0000:02:00.2"
 	vf23PciAddr     = "0000:02:00.3"
+	skipDriverCheck = "true"
 )
 
 func TestReadConfigFile(t *testing.T) {
@@ -68,6 +69,7 @@ func TestReadConfigFile(t *testing.T) {
 						IOMMUGroup: 2,
 					},
 				},
+				SkipDriverCheck: skipDriverCheck,
 			},
 			pf2PciAddr: {
 				PFKernelDriver: pfKernelDriver,
@@ -94,6 +96,7 @@ func TestReadConfigFile(t *testing.T) {
 						IOMMUGroup: 3,
 					},
 				},
+				SkipDriverCheck: skipDriverCheck,
 			},
 		},
 	}, cfg)

--- a/pkg/sriov/resource/config.yml
+++ b/pkg/sriov/resource/config.yml
@@ -1,6 +1,7 @@
 ---
 physicalFunctions:
   0000:01:00.0:
+    skipDriverCheck: true
     pfKernelDriver: pf-driver
     vfKernelDriver: vf-driver
     capabilities:
@@ -12,6 +13,7 @@ physicalFunctions:
       - address: 0000:01:00.1
         iommuGroup: 1
   0000:02:00.0:
+    skipDriverCheck: true
     pfKernelDriver: pf-driver
     vfKernelDriver: vf-driver
     capabilities:
@@ -25,6 +27,7 @@ physicalFunctions:
       - address: 0000:02:00.2
         iommuGroup: 2
   0000:03:00.0:
+    skipDriverCheck: true
     pfKernelDriver: pf-driver
     vfKernelDriver: vf-driver
     capabilities:

--- a/pkg/sriov/token/config.yml
+++ b/pkg/sriov/token/config.yml
@@ -1,6 +1,7 @@
 ---
 physicalFunctions:
   0000:01:00.0:
+    skipDriverCheck: true
     pfKernelDriver: pf-driver
     vfKernelDriver: vf-driver
     capabilities:
@@ -12,6 +13,7 @@ physicalFunctions:
       - address: 0000:01:00.1
         iommuGroup: 1
   0000:02:00.0:
+    skipDriverCheck: true
     pfKernelDriver: pf-driver
     vfKernelDriver: vf-driver
     capabilities:


### PR DESCRIPTION
The PR #322 is not sufficient to make VLAN trunking feature to work end to end as there is one more check done [here](https://github.com/networkservicemesh/sdk-sriov/blob/main/pkg/networkservice/common/resourcepool/common.go#L133) which may not work when second ns client shows up (i.e. no kernel interface for VF on host net ns at this point). This issue was reproducible only today as its purely a timing issue when multiple clients are brought up together.

Now `skipDriverCheck` flag can be configured from `sriov.config` file, once this PR is merged we may have to update deployments which uses `sriov.config` file.

/cc @JanScheurich I know you've already mentioned that PR # 322 was not an appropriate solution to fix this  :) hope now the issue is addressed properly.