### PR TITLE
Delete vfconfig on error/close

### DIFF
--- a/pkg/networkservice/common/resourcepool/server.go
+++ b/pkg/networkservice/common/resourcepool/server.go
@@ -1,4 +1,6 @@
-// Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2023 Doc.ai and/or its affiliates.
+//
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -84,6 +86,7 @@ func (s *resourcePoolServer) Request(ctx context.Context, request *networkservic
 
 	conn, err := next.Server(ctx).Request(ctx, request)
 	if err != nil && !vfExists {
+		vfconfig.Delete(ctx, metadata.IsClient(s))
 		if closeErr := s.resourcePool.close(conn); closeErr != nil {
 			err = errors.Wrapf(err, "connection closed with error: %s", closeErr.Error())
 		}
@@ -96,6 +99,7 @@ func (s *resourcePoolServer) Request(ctx context.Context, request *networkservic
 func (s *resourcePoolServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
 	_, err := next.Server(ctx).Close(ctx, conn)
 
+	vfconfig.Delete(ctx, metadata.IsClient(s))
 	closeErr := s.resourcePool.close(conn)
 
 	if err != nil && closeErr != nil {


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/sdk-sriov/issues/489

Cleanup `vfconfig` map on error or `Close`

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>