### PR TITLE
[qfix] Delete metadata.NewServer() from forwarder

### DIFF
--- a/pkg/networkservice/chains/forwarder/server.go
+++ b/pkg/networkservice/chains/forwarder/server.go
@@ -1,8 +1,8 @@
-// Copyright (c) 2020-2022 Doc.ai and/or its affiliates.
+// Copyright (c) 2020-2023 Doc.ai and/or its affiliates.
 //
-// Copyright (c) 2021-2022 Nordix Foundation.
+// Copyright (c) 2021-2023 Nordix Foundation.
 //
-// Copyright (c) 2022 Cisco and/or its affiliates.
+// Copyright (c) 2022-2023 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -51,7 +51,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/roundrobin"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/switchcase"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/utils/metadata"
 	"github.com/networkservicemesh/sdk/pkg/tools/token"
 
 	"github.com/networkservicemesh/sdk-sriov/pkg/networkservice/common/mechanisms/noop"
@@ -111,7 +110,6 @@ func NewServer(
 
 	resourceLock := &sync.Mutex{}
 	additionalFunctionality := []networkservice.NetworkServiceServer{
-		metadata.NewServer(),
 		recvfd.NewServer(),
 		discover.NewServer(nsClient, nseClient),
 		roundrobin.NewServer(),


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/sdk-sriov/issues/489

`endpoint.NewServer` already contains it.

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>