### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,8 +30,6 @@ jobs:
     name: Create release
     needs: get-tag
     uses: networkservicemesh/.github/.github/workflows/release.yaml@main
-    with:
-      tag: ${{ needs.get-tag.outputs.tag }}
     secrets:
       token: ${{ secrets.NSM_BOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description
Release workflow doesn't need get-tag job now. It has its own get-tag job.

## PR link
https://github.com/networkservicemesh/.github/pull/26